### PR TITLE
#36 Fixed login credentials not showing when app is put in background

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,6 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT" />
+        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
         </activity>
         <activity
             android:name=".LoginActivity"
-            android:noHistory="true"
+            android:noHistory="false"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.Login" />
         <activity


### PR DESCRIPTION
- set "noHistory" flag to false for LoginActivity in AndroidManifest.xml