### PR TITLE
Prevent sending answers multiple times 113

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -8,6 +8,12 @@
         </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+          </set>
+        </option>
         <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>

--- a/app/src/main/java/ro/code4/monitorizarevot/adapter/SyncAdapter.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/adapter/SyncAdapter.java
@@ -98,7 +98,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
 
     private void postQuestionAnswers() {
         try {
-            List<QuestionAnswer> questionAnswers = Data.getInstance().getUnsyncedQuestionAnswersFromForm();
+            List<QuestionAnswer> questionAnswers = Data.getInstance().getUnsyncedQuestionAnswersFromAllForms();
             NetworkService.postQuestionAnswer(new ResponseAnswerContainer(questionAnswers));
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/src/main/java/ro/code4/monitorizarevot/adapter/SyncAdapter.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/adapter/SyncAdapter.java
@@ -10,7 +10,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import ro.code4.monitorizarevot.constants.FormType;
@@ -20,7 +19,6 @@ import ro.code4.monitorizarevot.net.NetworkService;
 import ro.code4.monitorizarevot.net.model.*;
 import ro.code4.monitorizarevot.net.model.response.VersionResponse;
 import ro.code4.monitorizarevot.observable.ObservableListener;
-import ro.code4.monitorizarevot.util.FormUtils;
 import ro.code4.monitorizarevot.util.Logify;
 
 import static ro.code4.monitorizarevot.util.AuthUtils.createSyncAccount;
@@ -100,10 +98,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
 
     private void postQuestionAnswers() {
         try {
-            List<QuestionAnswer> questionAnswers = new ArrayList<>();
-            getAnswersFromForm(Data.getInstance().getFirstForm(), questionAnswers);
-            getAnswersFromForm(Data.getInstance().getSecondForm(), questionAnswers);
-            getAnswersFromForm(Data.getInstance().getThirdForm(), questionAnswers);
+            List<QuestionAnswer> questionAnswers = Data.getInstance().getUnsyncedQuestionAnswersFromForm();
             NetworkService.postQuestionAnswer(new ResponseAnswerContainer(questionAnswers));
         } catch (IOException e) {
             e.printStackTrace();
@@ -118,20 +113,6 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
                 Data.getInstance().deleteNote(note);
             } catch (IOException e) {
                 e.printStackTrace();
-            }
-        }
-    }
-
-    private void getAnswersFromForm(Form form, List<QuestionAnswer> questionAnswers) {
-        if (form != null) {
-            List<Question> questionList = FormUtils.getAllQuestions(form.getId());
-            for (Question question : questionList) {
-                if (!question.isSynced()) {
-                    for (BranchQuestionAnswer branchQuestionAnswer : Data.getInstance().getCityBranchPerQuestion(question.getId())) {
-                        QuestionAnswer questionAnswer = new QuestionAnswer(branchQuestionAnswer, form.getId());
-                        questionAnswers.add(questionAnswer);
-                    }
-                }
             }
         }
     }

--- a/app/src/main/java/ro/code4/monitorizarevot/db/Data.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/db/Data.java
@@ -240,7 +240,7 @@ public class Data {
         return branchQuestionAnswers;
     }
 
-    public List<QuestionAnswer> getUnsyncedQuestionAnswersFromForm() {
+    public List<QuestionAnswer> getUnsyncedQuestionAnswersFromAllForms() {
         List<QuestionAnswer> result = new ArrayList<>();
         for (Form form: getAllForms()) {
             result.addAll(getUnsyncedQuestionAnswersFromForm(form));

--- a/app/src/main/java/ro/code4/monitorizarevot/db/Data.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/db/Data.java
@@ -1,7 +1,9 @@
 package ro.code4.monitorizarevot.db;
 
 import android.support.annotation.NonNull;
+import android.util.Log;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.realm.Realm;
@@ -14,9 +16,11 @@ import ro.code4.monitorizarevot.net.model.BranchQuestionAnswer;
 import ro.code4.monitorizarevot.net.model.Form;
 import ro.code4.monitorizarevot.net.model.Note;
 import ro.code4.monitorizarevot.net.model.Question;
+import ro.code4.monitorizarevot.net.model.QuestionAnswer;
 import ro.code4.monitorizarevot.net.model.Section;
 import ro.code4.monitorizarevot.net.model.Syncable;
 import ro.code4.monitorizarevot.net.model.Version;
+import ro.code4.monitorizarevot.util.FormUtils;
 
 public class Data {
     private static final String AUTO_INCREMENT_PRIMARY_KEY = "id";
@@ -79,6 +83,16 @@ public class Data {
         return getForm(FormType.THIRD);
     }
 
+    private List<Form> getAllForms() {
+        Realm realm = Realm.getDefaultInstance();
+        RealmResults<Form> formsRealmResults = realm
+                .where(Form.class)
+                .findAll();
+        List<Form> forms = realm.copyFromRealm(formsRealmResults);
+        realm.close();
+        return forms;
+    }
+
     public Form getForm(String formId) {
         Realm realm = Realm.getDefaultInstance();
         RealmResults<Form> results = realm
@@ -119,6 +133,9 @@ public class Data {
     }
 
     public void saveAnswerResponse(BranchQuestionAnswer branchQuestionAnswer) {
+        Log.d(Data.class.getName(), "Saving new answer for question " +
+                branchQuestionAnswer.getQuestionId() + " with " +
+                branchQuestionAnswer.getAnswers().size() + " answers!");
         Realm realm = Realm.getDefaultInstance();
         realm.beginTransaction();
         realm.copyToRealmOrUpdate(branchQuestionAnswer);
@@ -221,6 +238,46 @@ public class Data {
         List<BranchQuestionAnswer> branchQuestionAnswers = realm.copyFromRealm(result);
         realm.close();
         return branchQuestionAnswers;
+    }
+
+    public List<QuestionAnswer> getUnsyncedQuestionAnswersFromForm() {
+        List<QuestionAnswer> result = new ArrayList<>();
+        for (Form form: getAllForms()) {
+            result.addAll(getUnsyncedQuestionAnswersFromForm(form));
+        }
+
+        return result;
+    }
+
+    /**
+     *
+     * @param formId
+     * @return
+     */
+    public List<QuestionAnswer> getUnsyncedQuestionAnswersFromForm(String formId) {
+        List<Question> questionList = FormUtils.getAllQuestions(formId);
+        List<QuestionAnswer> questionAnswerList = new ArrayList<>();
+        for (Question question : questionList) {
+            // skip if already synced
+            if (question.isSynced()) {
+                continue ;
+            }
+            questionAnswerList.addAll(getAnswersForQuestionInForm(question, formId));
+        }
+        return questionAnswerList;
+    }
+
+    private List<QuestionAnswer> getUnsyncedQuestionAnswersFromForm(@NonNull Form form) {
+        return getUnsyncedQuestionAnswersFromForm(form.getId());
+    }
+
+    private List<QuestionAnswer> getAnswersForQuestionInForm(Question question, String formId) {
+        List<QuestionAnswer> questionAnswerList = new ArrayList<>();
+        for (BranchQuestionAnswer branchQuestionAnswer : Data.getInstance().getCityBranchPerQuestion(question.getId())) {
+            QuestionAnswer questionAnswer = new QuestionAnswer(branchQuestionAnswer, formId);
+            questionAnswerList.add(questionAnswer);
+        }
+        return questionAnswerList;
     }
 
     public <T extends Syncable & RealmModel> List<T> getUnsyncedList(Class<T> objectClass) {

--- a/app/src/main/java/ro/code4/monitorizarevot/fragment/QuestionFragment.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/fragment/QuestionFragment.java
@@ -145,8 +145,8 @@ public class QuestionFragment extends BaseFragment<QuestionViewModel> {
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
+    public void onPause() {
+        super.onPause();
         if (questionContainer != null && !isSaving) {
             navigator.onSaveAnswerIfCompleted(questionContainer);
         }

--- a/app/src/main/java/ro/code4/monitorizarevot/fragment/QuestionFragment.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/fragment/QuestionFragment.java
@@ -127,14 +127,12 @@ public class QuestionFragment extends BaseFragment<QuestionViewModel> {
         rootView.findViewById(R.id.question_wrapper).setOnTouchListener(new OnSwipeTouchListener(getActivity()) {
             @Override
             public void onSwipeLeft() {
-                navigator.onSaveAnswerIfCompleted(questionContainer);
                 navigator.onPrevious();
                 hideButtons();
             }
 
             @Override
             public void onSwipeRight() {
-                navigator.onSaveAnswerIfCompleted(questionContainer);
                 navigator.onNext();
             }
         });

--- a/app/src/main/java/ro/code4/monitorizarevot/fragment/QuestionsDetailsFragment.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/fragment/QuestionsDetailsFragment.java
@@ -20,7 +20,6 @@ import ro.code4.monitorizarevot.R;
 import ro.code4.monitorizarevot.adapter.SyncAdapter;
 import ro.code4.monitorizarevot.db.Data;
 import ro.code4.monitorizarevot.net.NetworkService;
-import ro.code4.monitorizarevot.net.model.Answer;
 import ro.code4.monitorizarevot.net.model.BranchQuestionAnswer;
 import ro.code4.monitorizarevot.net.model.Question;
 import ro.code4.monitorizarevot.net.model.QuestionAnswer;
@@ -167,7 +166,7 @@ public class QuestionsDetailsFragment extends BaseFragment<QuestionDetailsViewMo
             if (currentBranchQuestionAnswer == null) {
                 continue;
             }
-
+            Data.getInstance().saveAnswerResponse(currentBranchQuestionAnswer);
             branchQuestionAnswerList.add(currentBranchQuestionAnswer);
         }
 
@@ -180,6 +179,7 @@ public class QuestionsDetailsFragment extends BaseFragment<QuestionDetailsViewMo
                 .toArray(new BranchQuestionAnswer[branchQuestionAnswerList.size()]));
         Toast.makeText(getContext(),getString(R.string.question_confirmation_message),
                 Toast.LENGTH_SHORT).show();
+        Log.d(QuestionsDetailsFragment.class.getName(), "Sending new answers");
     }
 
     private BranchQuestionAnswer buildBranchQuestionAnswer(Question question,
@@ -188,9 +188,7 @@ public class QuestionsDetailsFragment extends BaseFragment<QuestionDetailsViewMo
             return null;
         }
 
-        BranchQuestionAnswer branchQuestionAnswer = new BranchQuestionAnswer(question.getId(), answers);
-        Data.getInstance().saveAnswerResponse(branchQuestionAnswer);
-        return branchQuestionAnswer;
+        return new BranchQuestionAnswer(question.getId(), answers);
     }
 
 

--- a/app/src/main/java/ro/code4/monitorizarevot/net/NetworkService.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/net/NetworkService.java
@@ -237,12 +237,6 @@ public class NetworkService {
         });
     }
 
-    public static ObservableRequest<Boolean> syncCurrentQuestion(final QuestionAnswer questionAnswer) {
-        ResponseAnswerContainer responseMapper = new ResponseAnswerContainer(
-                Collections.singletonList(questionAnswer));
-        return syncResponses(responseMapper);
-    }
-
     public static ObservableRequest<Boolean> syncQuestions(List<QuestionAnswer> questionAnswers) {
         ResponseAnswerContainer responseMapper = new ResponseAnswerContainer(questionAnswers);
         return syncResponses(responseMapper);

--- a/app/src/main/java/ro/code4/monitorizarevot/net/NetworkService.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/net/NetworkService.java
@@ -11,6 +11,7 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import io.realm.RealmObject;
@@ -237,12 +238,22 @@ public class NetworkService {
     }
 
     public static ObservableRequest<Boolean> syncCurrentQuestion(final QuestionAnswer questionAnswer) {
+        ResponseAnswerContainer responseMapper = new ResponseAnswerContainer(
+                Collections.singletonList(questionAnswer));
+        return syncResponses(responseMapper);
+    }
+
+    public static ObservableRequest<Boolean> syncQuestions(List<QuestionAnswer> questionAnswers) {
+        ResponseAnswerContainer responseMapper = new ResponseAnswerContainer(questionAnswers);
+        return syncResponses(responseMapper);
+    }
+
+    private static ObservableRequest<Boolean> syncResponses(final ResponseAnswerContainer container) {
         return new ObservableRequest<>(new ObservableRequest.OnRequested<Boolean>() {
             @Override
             public void onRequest(Subscriber<? super Boolean> subscriber) {
                 try {
-                    ResponseAnswerContainer responseMapper = new ResponseAnswerContainer(Arrays.asList(questionAnswer));
-                    postQuestionAnswer(responseMapper);
+                    postQuestionAnswer(container);
                     subscriber.onNext(true);
                     subscriber.onCompleted();
                 } catch (IOException e){

--- a/app/src/main/java/ro/code4/monitorizarevot/net/model/BranchDetails.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/net/model/BranchDetails.java
@@ -6,7 +6,7 @@ import com.google.gson.annotations.SerializedName;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
 
-public class BranchDetails extends RealmObject implements Syncable {
+public class BranchDetails extends RealmObject implements Syncable{
 
     // TODO serialized names to be translated when api is updated
     @PrimaryKey
@@ -46,7 +46,6 @@ public class BranchDetails extends RealmObject implements Syncable {
         this.countyCode = countyCode;
         this.branchNumber = branchNumber;
         this.id = countyCode + String.valueOf(branchNumber);
-        this.isSynced = false;
     }
 
     public BranchDetails(String countyCode, int branchNumber, boolean isUrban, boolean isFemale, String timeEnter, String timeLeave) {
@@ -86,11 +85,6 @@ public class BranchDetails extends RealmObject implements Syncable {
     }
 
     @Override
-    public void setSynced(boolean synced) {
-        isSynced = synced;
-    }
-
-    @Override
     public boolean equals(Object obj) {
         if (obj instanceof BranchDetails) {
             BranchDetails other = (BranchDetails) obj;
@@ -105,5 +99,15 @@ public class BranchDetails extends RealmObject implements Syncable {
                         (timeLeave != null && other.getTimeLeave() != null && timeLeave.equals(other.getTimeLeave())));
         }
         return false;
+    }
+
+    @Override
+    public void setSynced(boolean synced) {
+        this.isSynced = synced;
+    }
+
+    @Override
+    public boolean isSynced() {
+        return isSynced;
     }
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/net/model/Question.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/net/model/Question.java
@@ -12,7 +12,7 @@ import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
 import ro.code4.monitorizarevot.net.model.response.ResponseAnswer;
 
-public class Question extends RealmObject implements Serializable {
+public class Question extends RealmObject implements Serializable, Syncable {
 
     // TODO serialized names to be translated when api is updated
     @PrimaryKey
@@ -59,14 +59,6 @@ public class Question extends RealmObject implements Serializable {
         return answerList;
     }
 
-    public boolean isSynced() {
-        return isSynced;
-    }
-
-    public void setSynced(boolean synced) {
-        isSynced = synced;
-    }
-
     public BranchQuestionAnswer getBranchQuestionAnswer() {
         return branchQuestionAnswer;
     }
@@ -80,5 +72,15 @@ public class Question extends RealmObject implements Serializable {
             return branchQuestionAnswer.getAnswers();
         }
         return new ArrayList<>();
+    }
+
+    @Override
+    public void setSynced(boolean synced) {
+        this.isSynced = synced;
+    }
+
+    @Override
+    public boolean isSynced() {
+        return isSynced;
     }
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/net/model/Syncable.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/net/model/Syncable.java
@@ -2,4 +2,5 @@ package ro.code4.monitorizarevot.net.model;
 
 public interface Syncable {
     void setSynced(boolean synced);
+    boolean isSynced();
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/net/model/response/ResponseAnswer.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/net/model/response/ResponseAnswer.java
@@ -74,4 +74,27 @@ public class ResponseAnswer extends RealmObject implements Serializable {
     public void setBranchNumber(int branchNumber) {
         this.branchNumber = branchNumber;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResponseAnswer that = (ResponseAnswer) o;
+
+        return branchNumber == that.branchNumber &&
+                optionId.intValue() == that.optionId &&
+                (value == null ? that.value == null : value.equals(that.value)) &&
+                (countyCode == null ? that.countyCode == null : countyCode.equals(that.countyCode));
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + branchNumber;
+        result = prime * result + optionId;
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        result = prime * result + ((countyCode == null) ? 0 : countyCode.hashCode());
+        return result;
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,7 +83,7 @@
     <string name="question_next">Next</string>
     <string name="question_previous">Previous</string>
     <string name="question_finish">Send</string>
-    <string name="question_confirmation_message">Message send</string>
+    <string name="question_confirmation_message">Message sent</string>
 
     <!-- Notes -->
     <string name="note_title">Add a message</string>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
 
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "io.realm:realm-gradle-plugin:5.7.0"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Deleted calls to `navigator.onSaveAnswerIfCompleted(questionContainer);` in the swipe methods because the method is already called in `onDestroy()`
Create a map to batch answers and send them together 
Created methods for sending multiple answers
Sending answers as part of the `onDestroy()` method of parent fragment instead of seding for each question fragment