### PR TITLE
[Fix #122] API 28 HTTP clear text not permitted

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/constants/Constants.java
+++ b/app/src/main/java/ro/code4/monitorizarevot/constants/Constants.java
@@ -1,7 +1,7 @@
 package ro.code4.monitorizarevot.constants;
 
 public class Constants {
-    public static final String GUIDE_URL = "http://monitorizare-vot-ghid.azurewebsites.net/";
+    public static final String GUIDE_URL = "https://monitorizare-vot-ghid.azurewebsites.net/";
     public static final String ORGANISATION_WEB_URL = "https://code4.ro/";
     public static final String SERVICE_CENTER_PHONE_NUMBER = "0800 080 200";
     public static final String TIME_FORMAT = "HH:mm";


### PR DESCRIPTION
changed `GUIDE_URL` to point to https endpoint